### PR TITLE
Remove --registry from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ EXPOSE $APP_PORT
 
 COPY --from=builder /github.com/edgexfoundry/device-virtual/cmd /
 
-ENTRYPOINT ["/device-virtual","--registry","--profile=docker","--confdir=/res"]
+ENTRYPOINT ["/device-virtual","--profile=docker","--confdir=/res"]

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/edgexfoundry/device-virtual-go
 
 require (
-	github.com/edgexfoundry/device-sdk-go v0.0.0-20190525113747-79c5093a958b
-	github.com/edgexfoundry/go-mod-core-contracts v0.0.1
+	github.com/edgexfoundry/device-sdk-go v0.0.0-20190529004611-4ec3ceb83e9b
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.0
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20190321074620-2f0d2b0e0001 // indirect
 	golang.org/x/sys v0.0.0-20190411185658-b44545bcd369 // indirect


### PR DESCRIPTION
Should not include --registry in the command line. It is consistent with the C Device Services.

Fix #24 