### PR TITLE
Update the version of device-sdk-go to v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/edgexfoundry/device-virtual-go
 
 require (
-	github.com/edgexfoundry/device-sdk-go v0.0.0-20190606081126-e01baf7ec020
+	github.com/edgexfoundry/device-sdk-go v1.0.0
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.0
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20190321074620-2f0d2b0e0001 // indirect


### PR DESCRIPTION
The device-sdk-go is tagging the release v1.0.0, and all Device Services should use this dependency.
fix #43

Signed-off-by: Cloud Tsai <cloudxxx8@gmail.com>