### PR TITLE
Decouple the hardcoded device resource names

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,14 @@ depends_on:
 ```
 # How to use
 For now, Virtual Device Service contains 4 pre-defined devices as random value generators:
-* Random-Boolean-Device
-* Random-Integer-Device
-* Random-UnsignedInteger-Device
-* Random-Float-Device
+* [Random-Boolean-Device](https://github.com/edgexfoundry/device-virtual-go/blob/master/cmd/res/device.virtual.bool.yaml)
+* [Random-Integer-Device](https://github.com/edgexfoundry/device-virtual-go/blob/master/cmd/res/device.virtual.int.yaml)
+* [Random-UnsignedInteger-Device](https://github.com/edgexfoundry/device-virtual-go/blob/master/cmd/res/device.virtual.uint.yaml)
+* [Random-Float-Device](https://github.com/edgexfoundry/device-virtual-go/blob/master/cmd/res/device.virtual.float.yaml)
+Restricted:
+To control the randomization of device resource values, it has to add additional device resources with the prefix
+"EnableRandomization_" for each device resource. (Need to do the same for device commands and core commands)
+Please find the above default device profiles for example.
 
 Use Core-Command Service APIs to find executable commands information:
 * http://[host]:48082/api/v1/device/name/Random-Boolean-Device

--- a/cmd/res/device.virtual.bool.yaml
+++ b/cmd/res/device.virtual.bool.yaml
@@ -7,7 +7,7 @@ description: "Example of Device-Virtual"
 
 deviceResources:
 -
-  name: "EnableRandomization_Bool"
+  name: "EnableRandomization_RandomValue_Bool"
   description: "used to decide whether to re-generate a random value"
   properties:
     value:
@@ -29,9 +29,9 @@ deviceCommands:
   get:
     - { operation: "get", object: "RandomValue_Bool", parameter: "RandomValue_Bool" }
   set:
-    - { operation: "set", object: "EnableRandomization_Bool", parameter: "EnableRandomization_Bool" }
     - { operation: "set", object: "RandomValue_Bool", parameter: "RandomValue_Bool" }
-
+    - { operation: "set", object: "EnableRandomization_RandomValue_Bool", parameter: "EnableRandomization_RandomValue_Bool" }
+    
 coreCommands:
 -
   name: "RandomValue_Bool"
@@ -48,7 +48,7 @@ coreCommands:
         expectedValues: []
   put:
     path: "/api/v1/device/{deviceId}/RandomValue_Bool"
-    parameterNames: ["RandomValue_Bool","EnableRandomization_Bool"]
+    parameterNames: ["RandomValue_Bool","EnableRandomization_RandomValue_Bool"]
     responses:
       -
         code: "200"

--- a/cmd/res/device.virtual.float.yaml
+++ b/cmd/res/device.virtual.float.yaml
@@ -7,7 +7,7 @@ description: "Example of Device-Virtual"
 
 deviceResources:
 -
-  name: "EnableRandomization_Float32"
+  name: "EnableRandomization_RandomValue_Float32"
   description: "used to decide whether to re-generate a random value"
   properties:
     value:
@@ -15,7 +15,7 @@ deviceResources:
     units:
       { type: "String", readWrite: "R", defaultValue: "Random" }
 -
-  name: "EnableRandomization_Float64"
+  name: "EnableRandomization_RandomValue_Float64"
   description: "used to decide whether to re-generate a random value"
   properties:
     value:
@@ -46,14 +46,14 @@ deviceCommands:
     - { operation: "get", object: "RandomValue_Float32", parameter: "RandomValue_Float32" }
   set:
     - { operation: "set", object: "RandomValue_Float32", parameter: "RandomValue_Float32" }
-    - { operation: "set", object: "EnableRandomization_Float32", parameter: "EnableRandomization_Float32"}
+    - { operation: "set", object: "EnableRandomization_RandomValue_Float32", parameter: "EnableRandomization_RandomValue_Float32"}
 -
   name: "RandomValue_Float64"
   get:
     - { operation: "get", object: "RandomValue_Float64", parameter: "RandomValue_Float64" }
   set:
     - { operation: "set", object: "RandomValue_Float64", parameter: "RandomValue_Float64"}
-    - { operation: "set", object: "EnableRandomization_Float64", parameter: "EnableRandomization_Float64"}
+    - { operation: "set", object: "EnableRandomization_RandomValue_Float64", parameter: "EnableRandomization_RandomValue_Float64"}
 
 coreCommands:
 -
@@ -71,7 +71,7 @@ coreCommands:
         expectedValues: []
   put:
     path: "/api/v1/device/{deviceId}/RandomValue_Float32"
-    parameterNames: ["RandomValue_Float32","EnableRandomization_Float32"]
+    parameterNames: ["RandomValue_Float32","EnableRandomization_RandomValue_Float32"]
     responses:
       -
         code: "200"
@@ -94,7 +94,7 @@ coreCommands:
         expectedValues: []
   put:
     path: "/api/v1/device/{deviceId}/RandomValue_Float64"
-    parameterNames: ["RandomValue_Float64","EnableRandomization_Float64"]
+    parameterNames: ["RandomValue_Float64","EnableRandomization_RandomValue_Float64"]
     responses:
       -
         code: "200"

--- a/cmd/res/device.virtual.int.yaml
+++ b/cmd/res/device.virtual.int.yaml
@@ -7,7 +7,7 @@ description: "Example of Device-Virtual"
 
 deviceResources:
 -
-  name: "EnableRandomization_Int8"
+  name: "EnableRandomization_RandomValue_Int8"
   description: "used to decide whether to re-generate a random value"
   properties:
     value:
@@ -15,7 +15,7 @@ deviceResources:
     units:
       { type: "String", readWrite: "R", defaultValue: "Random" }
 -
-  name: "EnableRandomization_Int16"
+  name: "EnableRandomization_RandomValue_Int16"
   description: "used to decide whether to re-generate a random value"
   properties:
     value:
@@ -23,7 +23,7 @@ deviceResources:
     units:
       { type: "String", readWrite: "R", defaultValue: "Random" }
 -
-  name: "EnableRandomization_Int32"
+  name: "EnableRandomization_RandomValue_Int32"
   description: "used to decide whether to re-generate a random value"
   properties:
     value:
@@ -31,7 +31,7 @@ deviceResources:
     units:
       { type: "String", readWrite: "R", defaultValue: "Random" }
 -
-  name: "EnableRandomization_Int64"
+  name: "EnableRandomization_RandomValue_Int64"
   description: "used to decide whether to re-generate a random value"
   properties:
     value:
@@ -78,28 +78,28 @@ deviceCommands:
   - { operation: "get", object: "RandomValue_Int8", parameter: "RandomValue_Int8" }
   set:
   - { operation: "set", object: "RandomValue_Int8", parameter: "RandomValue_Int8" }
-  - { operation: "set", object: "EnableRandomization_Int8", parameter: "EnableRandomization_Int8" }
+  - { operation: "set", object: "EnableRandomization_RandomValue_Int8", parameter: "EnableRandomization_RandomValue_Int8" }
 -
   name: "RandomValue_Int16"
   get:
   - { operation: "get", object: "RandomValue_Int16", parameter: "RandomValue_Int16" }
   set:
   - { operation: "set", object: "RandomValue_Int16", parameter: "RandomValue_Int16" }
-  - { operation: "set", object: "EnableRandomization_Int16", parameter: "EnableRandomization_Int16" }
+  - { operation: "set", object: "EnableRandomization_RandomValue_Int16", parameter: "EnableRandomization_RandomValue_Int16" }
 -
   name: "RandomValue_Int32"
   get:
   - { operation: "get", object: "RandomValue_Int32", parameter: "RandomValue_Int32" }
   set:
   - { operation: "set", object: "RandomValue_Int32", parameter: "RandomValue_Int32" }
-  - { operation: "set", object: "EnableRandomization_Int32", parameter: "EnableRandomization_Int32" }
+  - { operation: "set", object: "EnableRandomization_RandomValue_Int32", parameter: "EnableRandomization_RandomValue_Int32" }
 -
   name: "RandomValue_Int64"
   get:
     - { operation: "get", object: "RandomValue_Int64", parameter: "RandomValue_Int64" }
   set:
     - { operation: "set", object: "RandomValue_Int64", parameter: "RandomValue_Int64" }
-    - { operation: "set", object: "EnableRandomization_Int64", parameter: "EnableRandomization_Int64" }
+    - { operation: "set", object: "EnableRandomization_RandomValue_Int64", parameter: "EnableRandomization_RandomValue_Int64" }
 
 coreCommands:
 -
@@ -117,7 +117,7 @@ coreCommands:
       expectedValues: []
   put:
     path: "/api/v1/device/{deviceId}/RandomValue_Int8"
-    parameterNames: ["RandomValue_Int8","EnableRandomization_Int8"]
+    parameterNames: ["RandomValue_Int8","EnableRandomization_RandomValue_Int8"]
     responses:
     -
       code: "200"
@@ -140,7 +140,7 @@ coreCommands:
       expectedValues: []
   put:
     path: "/api/v1/device/{deviceId}/RandomValue_Int16"
-    parameterNames: ["RandomValue_Int16","EnableRandomization_Int16"]
+    parameterNames: ["RandomValue_Int16","EnableRandomization_RandomValue_Int16"]
     responses:
     -
       code: "200"
@@ -163,7 +163,7 @@ coreCommands:
       expectedValues: []
   put:
     path: "/api/v1/device/{deviceId}/RandomValue_Int32"
-    parameterNames: ["RandomValue_Int32","EnableRandomization_Int32"]
+    parameterNames: ["RandomValue_Int32","EnableRandomization_RandomValue_Int32"]
     responses:
       -
         code: "200"
@@ -186,7 +186,7 @@ coreCommands:
         expectedValues: []
   put:
     path: "/api/v1/device/{deviceId}/RandomValue_Int64"
-    parameterNames: ["RandomValue_Int64","EnableRandomization_Int64"]
+    parameterNames: ["RandomValue_Int64","EnableRandomization_RandomValue_Int64"]
     responses:
       -
         code: "200"

--- a/cmd/res/device.virtual.uint.yaml
+++ b/cmd/res/device.virtual.uint.yaml
@@ -7,7 +7,7 @@ description: "Example of Device-Virtual"
 
 deviceResources:
 -
-  name: "EnableRandomization_Uint8"
+  name: "EnableRandomization_RandomValue_Uint8"
   description: "used to decide whether to re-generate a random value"
   properties:
     value:
@@ -15,7 +15,7 @@ deviceResources:
     units:
       { type: "String", readWrite: "R", defaultValue: "Random" }
 -
-  name: "EnableRandomization_Uint16"
+  name: "EnableRandomization_RandomValue_Uint16"
   description: "used to decide whether to re-generate a random value"
   properties:
     value:
@@ -23,7 +23,7 @@ deviceResources:
     units:
       { type: "String", readWrite: "R", defaultValue: "Random" }
 -
-  name: "EnableRandomization_Uint32"
+  name: "EnableRandomization_RandomValue_Uint32"
   description: "used to decide whether to re-generate a random value"
   properties:
     value:
@@ -31,7 +31,7 @@ deviceResources:
     units:
       { type: "String", readWrite: "R", defaultValue: "Random" }
 -
-  name: "EnableRandomization_Uint64"
+  name: "EnableRandomization_RandomValue_Uint64"
   description: "used to decide whether to re-generate a random value"
   properties:
     value:
@@ -78,28 +78,28 @@ deviceCommands:
   - { operation: "get", object: "RandomValue_Uint8", parameter: "RandomValue_Uint8" }
   set:
   - { operation: "set", object: "RandomValue_Uint8", parameter: "RandomValue_Uint8" }
-  - { operation: "set", object: "EnableRandomization_Uint8", parameter: "EnableRandomization_Uint8" }
+  - { operation: "set", object: "EnableRandomization_RandomValue_Uint8", parameter: "EnableRandomization_RandomValue_Uint8" }
 -
   name: "RandomValue_Uint16"
   get:
   - { operation: "get", object: "RandomValue_Uint16", parameter: "RandomValue_Uint16" }
   set:
   - { operation: "set", object: "RandomValue_Uint16", parameter: "RandomValue_Uint16" }
-  - { operation: "set", object: "EnableRandomization_Uint16", parameter: "EnableRandomization_Uint16" }
+  - { operation: "set", object: "EnableRandomization_RandomValue_Uint16", parameter: "EnableRandomization_RandomValue_Uint16" }
 -
   name: "RandomValue_Uint32"
   get:
   - { operation: "get", object: "RandomValue_Uint32", parameter: "RandomValue_Uint32" }
   set:
   - { operation: "set", object: "RandomValue_Uint32", parameter: "RandomValue_Uint32" }
-  - { operation: "set", object: "EnableRandomization_Uint32", parameter: "EnableRandomization_Uint32" }
+  - { operation: "set", object: "EnableRandomization_RandomValue_Uint32", parameter: "EnableRandomization_RandomValue_Uint32" }
 -
   name: "RandomValue_Uint64"
   get:
     - { operation: "get", object: "RandomValue_Uint64", parameter: "RandomValue_Uint64" }
   set:
     - { operation: "set", object: "RandomValue_Uint64", parameter: "RandomValue_Uint64" }
-    - { operation: "set", object: "EnableRandomization_Uint64", parameter: "EnableRandomization_Uint64" }
+    - { operation: "set", object: "EnableRandomization_RandomValue_Uint64", parameter: "EnableRandomization_RandomValue_Uint64" }
 
 coreCommands:
 -
@@ -117,7 +117,7 @@ coreCommands:
       expectedValues: []
   put:
     path: "/api/v1/device/{deviceId}/RandomValue_Uint8"
-    parameterNames: ["RandomValue_Uint8","EnableRandomization_Uint8"]
+    parameterNames: ["RandomValue_Uint8","EnableRandomization_RandomValue_Uint8"]
     responses:
     -
       code: "200"
@@ -140,7 +140,7 @@ coreCommands:
       expectedValues: []
   put:
     path: "/api/v1/device/{deviceId}/RandomValue_Uint16"
-    parameterNames: ["RandomValue_Uint16","EnableRandomization_Uint16"]
+    parameterNames: ["RandomValue_Uint16","EnableRandomization_RandomValue_Uint16"]
     responses:
     -
       code: "200"
@@ -163,7 +163,7 @@ coreCommands:
       expectedValues: []
   put:
     path: "/api/v1/device/{deviceId}/RandomValue_Uint32"
-    parameterNames: ["RandomValue_Uint32","EnableRandomization_Uint32"]
+    parameterNames: ["RandomValue_Uint32","EnableRandomization_RandomValue_Uint32"]
     responses:
       -
         code: "200"
@@ -186,7 +186,7 @@ coreCommands:
         expectedValues: []
   put:
     path: "/api/v1/device/{deviceId}/RandomValue_Uint64"
-    parameterNames: ["RandomValue_Uint64","EnableRandomization_Uint64"]
+    parameterNames: ["RandomValue_Uint64","EnableRandomization_RandomValue_Uint64"]
     responses:
       -
         code: "200"

--- a/driver/resourcebool.go
+++ b/driver/resourcebool.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
+	"strings"
 	"time"
 
 	dsModels "github.com/edgexfoundry/device-sdk-go/pkg/models"
@@ -40,20 +41,18 @@ func (rb *resourceBool) value(db *db, deviceName, deviceResourceName string) (*d
 }
 
 func (rb *resourceBool) write(param *dsModels.CommandValue, deviceName string, db *db) error {
-	switch param.DeviceResourceName {
-	case deviceResourceEnableRandomizationBool:
+	enableRandomizationPrefix := "EnableRandomization_"
+	if strings.Contains(param.DeviceResourceName, enableRandomizationPrefix) {
 		if v, err := param.BoolValue(); err == nil {
-			return db.updateResourceRandomization(v, deviceName, deviceResourceBool)
+			return db.updateResourceRandomization(v, deviceName, param.DeviceResourceName[len(enableRandomizationPrefix):len(param.DeviceResourceName)])
 		} else {
 			return fmt.Errorf("resourceBool.write: %v", err)
 		}
-	case deviceResourceBool:
+	} else {
 		if _, err := param.BoolValue(); err == nil {
-			return db.updateResourceValue(param.ValueToString(), deviceName, deviceResourceBool, true)
+			return db.updateResourceValue(param.ValueToString(), deviceName, param.DeviceResourceName, true)
 		} else {
 			return fmt.Errorf("resourceBool.write: %v", err)
 		}
-	default:
-		return fmt.Errorf("resourceBool.write: unknown device resource: %s", param.DeviceResourceName)
 	}
 }

--- a/driver/resourcefloat.go
+++ b/driver/resourcefloat.go
@@ -104,26 +104,14 @@ func parseFloatMinimumMaximum(minimum, maximum, dataType string) (float64, float
 }
 
 func (rf *resourceFloat) write(param *dsModels.CommandValue, deviceName string, db *db) error {
-	switch param.DeviceResourceName {
-	case deviceResourceEnableRandomizationFloat32:
-		if v, err := param.BoolValue(); err == nil {
-			return db.updateResourceRandomization(v, deviceName, deviceResourceFloat32)
-		} else {
-			return fmt.Errorf("resourceFloat.write: %v", err)
-		}
-	case deviceResourceEnableRandomizationFloat64:
-		if v, err := param.BoolValue(); err == nil {
-			return db.updateResourceRandomization(v, deviceName, deviceResourceFloat64)
-		} else {
-			return fmt.Errorf("resourceFloat.write: %v", err)
-		}
-	case deviceResourceFloat32:
+	switch param.Type {
+	case dsModels.Float32:
 		if v, err := param.Float32Value(); err == nil {
 			return db.updateResourceValue(strconv.FormatFloat(float64(v), 'e', -1, 32), deviceName, param.DeviceResourceName, true)
 		} else {
 			return fmt.Errorf("resourceFloat.write: %v", err)
 		}
-	case deviceResourceFloat64:
+	case dsModels.Float64:
 		if v, err := param.Float64Value(); err == nil {
 			return db.updateResourceValue(strconv.FormatFloat(float64(v), 'e', -1, 64), deviceName, param.DeviceResourceName, true)
 		} else {

--- a/driver/resourceint.go
+++ b/driver/resourceint.go
@@ -152,52 +152,28 @@ func randomInt(min, max int64) int64 {
 }
 
 func (ri *resourceInt) write(param *dsModels.CommandValue, deviceName string, db *db) error {
-	switch param.DeviceResourceName {
-	case deviceResourceEnableRandomizationInt8:
-		if v, err := param.BoolValue(); err == nil {
-			return db.updateResourceRandomization(v, deviceName, deviceResourceInt8)
-		} else {
-			return fmt.Errorf("resourceInt.write: %v", err)
-		}
-	case deviceResourceEnableRandomizationInt16:
-		if v, err := param.BoolValue(); err == nil {
-			return db.updateResourceRandomization(v, deviceName, deviceResourceInt16)
-		} else {
-			return fmt.Errorf("resourceInt.write: %v", err)
-		}
-	case deviceResourceEnableRandomizationInt32:
-		if v, err := param.BoolValue(); err == nil {
-			return db.updateResourceRandomization(v, deviceName, deviceResourceInt32)
-		} else {
-			return fmt.Errorf("resourceInt.write: %v", err)
-		}
-	case deviceResourceEnableRandomizationInt64:
-		if v, err := param.BoolValue(); err == nil {
-			return db.updateResourceRandomization(v, deviceName, deviceResourceInt64)
-		} else {
-			return fmt.Errorf("resourceInt.write: %v", err)
-		}
-	case deviceResourceInt8:
+	switch param.Type {
+	case dsModels.Int8:
 		if _, err := param.Int8Value(); err == nil {
-			return db.updateResourceValue(param.ValueToString(), deviceName, deviceResourceInt8, true)
+			return db.updateResourceValue(param.ValueToString(), deviceName, param.DeviceResourceName, true)
 		} else {
 			return fmt.Errorf("resourceInt.write: %v", err)
 		}
-	case deviceResourceInt16:
+	case dsModels.Int16:
 		if _, err := param.Int16Value(); err == nil {
-			return db.updateResourceValue(param.ValueToString(), deviceName, deviceResourceInt16, true)
+			return db.updateResourceValue(param.ValueToString(), deviceName, param.DeviceResourceName, true)
 		} else {
 			return fmt.Errorf("resourceInt.write: %v", err)
 		}
-	case deviceResourceInt32:
+	case dsModels.Int32:
 		if _, err := param.Int32Value(); err == nil {
-			return db.updateResourceValue(param.ValueToString(), deviceName, deviceResourceInt32, true)
+			return db.updateResourceValue(param.ValueToString(), deviceName, param.DeviceResourceName, true)
 		} else {
 			return fmt.Errorf("resourceInt.write: %v", err)
 		}
-	case deviceResourceInt64:
+	case dsModels.Int64:
 		if _, err := param.Int64Value(); err == nil {
-			return db.updateResourceValue(param.ValueToString(), deviceName, deviceResourceInt64, true)
+			return db.updateResourceValue(param.ValueToString(), deviceName, param.DeviceResourceName, true)
 		} else {
 			return fmt.Errorf("resourceInt.write: %v", err)
 		}

--- a/driver/resourceuint.go
+++ b/driver/resourceuint.go
@@ -134,52 +134,28 @@ func parseUintMinimumMaximum(minimum, maximum, dataType string) (uint64, uint64,
 }
 
 func (ru *resourceUint) write(param *dsModels.CommandValue, deviceName string, db *db) error {
-	switch param.DeviceResourceName {
-	case deviceResourceEnableRandomizationUint8:
-		if v, err := param.BoolValue(); err == nil {
-			return db.updateResourceRandomization(v, deviceName, deviceResourceUint8)
-		} else {
-			return fmt.Errorf("resourceUint.write: %v", err)
-		}
-	case deviceResourceEnableRandomizationUint16:
-		if v, err := param.BoolValue(); err == nil {
-			return db.updateResourceRandomization(v, deviceName, deviceResourceUint16)
-		} else {
-			return fmt.Errorf("resourceUint.write: %v", err)
-		}
-	case deviceResourceEnableRandomizationUint32:
-		if v, err := param.BoolValue(); err == nil {
-			return db.updateResourceRandomization(v, deviceName, deviceResourceUint32)
-		} else {
-			return fmt.Errorf("resourceUint.write: %v", err)
-		}
-	case deviceResourceEnableRandomizationUint64:
-		if v, err := param.BoolValue(); err == nil {
-			return db.updateResourceRandomization(v, deviceName, deviceResourceUint64)
-		} else {
-			return fmt.Errorf("resourceUint.write: %v", err)
-		}
-	case deviceResourceUint8:
+	switch param.Type {
+	case dsModels.Uint8:
 		if _, err := param.Uint8Value(); err == nil {
-			return db.updateResourceValue(param.ValueToString(), deviceName, deviceResourceUint8, true)
+			return db.updateResourceValue(param.ValueToString(), deviceName, param.DeviceResourceName, true)
 		} else {
 			return fmt.Errorf("resourceUint.write: %v", err)
 		}
-	case deviceResourceUint16:
+	case dsModels.Uint16:
 		if _, err := param.Uint16Value(); err == nil {
-			return db.updateResourceValue(param.ValueToString(), deviceName, deviceResourceUint16, true)
+			return db.updateResourceValue(param.ValueToString(), deviceName, param.DeviceResourceName, true)
 		} else {
 			return fmt.Errorf("resourceUint.write: %v", err)
 		}
-	case deviceResourceUint32:
+	case dsModels.Uint32:
 		if _, err := param.Uint32Value(); err == nil {
-			return db.updateResourceValue(param.ValueToString(), deviceName, deviceResourceUint32, true)
+			return db.updateResourceValue(param.ValueToString(), deviceName, param.DeviceResourceName, true)
 		} else {
 			return fmt.Errorf("resourceUint.write: %v", err)
 		}
-	case deviceResourceUint64:
+	case dsModels.Uint64:
 		if _, err := param.Uint64Value(); err == nil {
-			return db.updateResourceValue(param.ValueToString(), deviceName, deviceResourceUint64, true)
+			return db.updateResourceValue(param.ValueToString(), deviceName, param.DeviceResourceName, true)
 		} else {
 			return fmt.Errorf("resourceUint.write: %v", err)
 		}

--- a/driver/virtualdevice.go
+++ b/driver/virtualdevice.go
@@ -13,39 +13,17 @@ import (
 )
 
 const (
-	typeBool                                 = "Bool"
-	typeInt8                                 = "Int8"
-	typeInt16                                = "Int16"
-	typeInt32                                = "Int32"
-	typeInt64                                = "Int64"
-	typeUint8                                = "Uint8"
-	typeUint16                               = "Uint16"
-	typeUint32                               = "Uint32"
-	typeUint64                               = "Uint64"
-	typeFloat32                              = "Float32"
-	typeFloat64                              = "Float64"
-	deviceResourceEnableRandomizationBool    = "EnableRandomization_Bool"
-	deviceResourceEnableRandomizationInt8    = "EnableRandomization_Int8"
-	deviceResourceEnableRandomizationInt16   = "EnableRandomization_Int16"
-	deviceResourceEnableRandomizationInt32   = "EnableRandomization_Int32"
-	deviceResourceEnableRandomizationInt64   = "EnableRandomization_Int64"
-	deviceResourceEnableRandomizationUint8   = "EnableRandomization_Uint8"
-	deviceResourceEnableRandomizationUint16  = "EnableRandomization_Uint16"
-	deviceResourceEnableRandomizationUint32  = "EnableRandomization_Uint32"
-	deviceResourceEnableRandomizationUint64  = "EnableRandomization_Uint64"
-	deviceResourceEnableRandomizationFloat32 = "EnableRandomization_Float32"
-	deviceResourceEnableRandomizationFloat64 = "EnableRandomization_Float64"
-	deviceResourceBool                       = "RandomValue_Bool"
-	deviceResourceInt8                       = "RandomValue_Int8"
-	deviceResourceInt16                      = "RandomValue_Int16"
-	deviceResourceInt32                      = "RandomValue_Int32"
-	deviceResourceInt64                      = "RandomValue_Int64"
-	deviceResourceUint8                      = "RandomValue_Uint8"
-	deviceResourceUint16                     = "RandomValue_Uint16"
-	deviceResourceUint32                     = "RandomValue_Uint32"
-	deviceResourceUint64                     = "RandomValue_Uint64"
-	deviceResourceFloat32                    = "RandomValue_Float32"
-	deviceResourceFloat64                    = "RandomValue_Float64"
+	typeBool    = "Bool"
+	typeInt8    = "Int8"
+	typeInt16   = "Int16"
+	typeInt32   = "Int32"
+	typeInt64   = "Int64"
+	typeUint8   = "Uint8"
+	typeUint16  = "Uint16"
+	typeUint32  = "Uint32"
+	typeUint64  = "Uint64"
+	typeFloat32 = "Float32"
+	typeFloat64 = "Float64"
 )
 
 type virtualDevice struct {
@@ -55,17 +33,17 @@ type virtualDevice struct {
 	resourceFloat *resourceFloat
 }
 
-func (d *virtualDevice) read(deviceName, deviceResourceName, minimum, maximum string, db *db) (*dsModels.CommandValue, error) {
+func (d *virtualDevice) read(deviceName, deviceResourceName, typeName, minimum, maximum string, db *db) (*dsModels.CommandValue, error) {
 	result := &dsModels.CommandValue{}
-
-	switch deviceResourceName {
-	case deviceResourceBool:
+	valueType := dsModels.ParseValueType(typeName)
+	switch valueType {
+	case dsModels.Bool:
 		return d.resourceBool.value(db, deviceName, deviceResourceName)
-	case deviceResourceInt8, deviceResourceInt16, deviceResourceInt32, deviceResourceInt64:
+	case dsModels.Int8, dsModels.Int16, dsModels.Int32, dsModels.Int64:
 		return d.resourceInt.value(db, deviceName, deviceResourceName, minimum, maximum)
-	case deviceResourceUint8, deviceResourceUint16, deviceResourceUint32, deviceResourceUint64:
+	case dsModels.Uint8, dsModels.Uint16, dsModels.Uint32, dsModels.Uint64:
 		return d.resourceUint.value(db, deviceName, deviceResourceName, minimum, maximum)
-	case deviceResourceFloat32, deviceResourceFloat64:
+	case dsModels.Float32, dsModels.Float64:
 		return d.resourceFloat.value(db, deviceName, deviceResourceName, minimum, maximum)
 	default:
 		return result, fmt.Errorf("virtualDevice.read: wrong read type: %s", deviceResourceName)
@@ -73,14 +51,14 @@ func (d *virtualDevice) read(deviceName, deviceResourceName, minimum, maximum st
 }
 
 func (d *virtualDevice) write(param *dsModels.CommandValue, deviceName string, db *db) error {
-	switch param.DeviceResourceName {
-	case deviceResourceEnableRandomizationBool, deviceResourceBool:
+	switch param.Type {
+	case dsModels.Bool:
 		return d.resourceBool.write(param, deviceName, db)
-	case deviceResourceEnableRandomizationInt8, deviceResourceEnableRandomizationInt16, deviceResourceEnableRandomizationInt32, deviceResourceEnableRandomizationInt64, deviceResourceInt8, deviceResourceInt16, deviceResourceInt32, deviceResourceInt64:
+	case dsModels.Int8, dsModels.Int16, dsModels.Int32, dsModels.Int64:
 		return d.resourceInt.write(param, deviceName, db)
-	case deviceResourceEnableRandomizationUint8, deviceResourceEnableRandomizationUint16, deviceResourceEnableRandomizationUint32, deviceResourceEnableRandomizationUint64, deviceResourceUint8, deviceResourceUint16, deviceResourceUint32, deviceResourceUint64:
+	case dsModels.Uint8, dsModels.Uint16, dsModels.Uint32, dsModels.Uint64:
 		return d.resourceUint.write(param, deviceName, db)
-	case deviceResourceEnableRandomizationFloat32, deviceResourceEnableRandomizationFloat64, deviceResourceFloat32, deviceResourceFloat64:
+	case dsModels.Float32, dsModels.Float64:
 		return d.resourceFloat.write(param, deviceName, db)
 	default:
 		return fmt.Errorf("VirtualDriver.HandleWriteCommands: there is no matched device resource for %s", param.String())

--- a/driver/virtualdevice_test.go
+++ b/driver/virtualdevice_test.go
@@ -10,6 +10,17 @@ import (
 )
 
 const (
+	deviceResourceBool       = "RandomValue_Bool"
+	deviceResourceInt8       = "RandomValue_Int8"
+	deviceResourceInt16      = "RandomValue_Int16"
+	deviceResourceInt32      = "RandomValue_Int32"
+	deviceResourceInt64      = "RandomValue_Int64"
+	deviceResourceUint8      = "RandomValue_Uint8"
+	deviceResourceUint16     = "RandomValue_Uint16"
+	deviceResourceUint32     = "RandomValue_Uint32"
+	deviceResourceUint64     = "RandomValue_Uint64"
+	deviceResourceFloat32    = "RandomValue_Float32"
+	deviceResourceFloat64    = "RandomValue_Float64"
 	deviceName               = "Random-Value-Device"
 	deviceCommandNameBool    = "RandomValue_Bool"
 	deviceCommandNameInt8    = "RandomValue_Int8"
@@ -89,7 +100,7 @@ func TestValue_Bool(t *testing.T) {
 	}()
 
 	vd := newVirtualDevice()
-	v1, err := vd.read(deviceName, deviceResourceBool, "", "", db)
+	v1, err := vd.read(deviceName, deviceResourceBool, typeBool, "", "", db)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +114,7 @@ func TestValue_Bool(t *testing.T) {
 	rounds := 20
 	//EnableRandomization = true
 	for x := 1; x <= rounds; x++ {
-		v2, _ := vd.read(deviceName, deviceResourceBool, "", "", db)
+		v2, _ := vd.read(deviceName, deviceResourceBool, typeBool, "", "", db)
 		b2, _ := v2.BoolValue()
 		if b1 != b2 {
 			break
@@ -118,10 +129,10 @@ func TestValue_Bool(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	v1, _ = vd.read(deviceName, deviceResourceBool, "", "", db)
+	v1, _ = vd.read(deviceName, deviceResourceBool, typeBool, "", "", db)
 	b1, _ = v1.BoolValue()
 	for x := 0; x <= rounds; x++ {
-		v2, _ := vd.read(deviceName, deviceResourceBool, "", "", db)
+		v2, _ := vd.read(deviceName, deviceResourceBool, typeBool, "", "", db)
 		b2, _ := v2.BoolValue()
 		if b1 != b2 {
 			t.Fatalf("EnableRandomization is false, but got different read")
@@ -130,35 +141,35 @@ func TestValue_Bool(t *testing.T) {
 }
 
 func TestValueIntx(t *testing.T) {
-	ValueIntx(t, deviceResourceInt8, "-128", "127")
-	ValueIntx(t, deviceResourceInt8, "", "")
-	ValueIntx(t, deviceResourceInt16, "-32768", "32767")
-	ValueIntx(t, deviceResourceInt16, "", "")
-	ValueIntx(t, deviceResourceInt32, "-2147483648", "2147483647")
-	ValueIntx(t, deviceResourceInt32, "", "")
-	ValueIntx(t, deviceResourceInt64, "-9223372036854775808", "9223372036854775807")
-	ValueIntx(t, deviceResourceInt64, "", "")
+	ValueIntx(t, deviceResourceInt8, typeInt8, "-128", "127")
+	ValueIntx(t, deviceResourceInt8, typeInt8, "", "")
+	ValueIntx(t, deviceResourceInt16, typeInt16, "-32768", "32767")
+	ValueIntx(t, deviceResourceInt16, typeInt16, "", "")
+	ValueIntx(t, deviceResourceInt32, typeInt32, "-2147483648", "2147483647")
+	ValueIntx(t, deviceResourceInt32, typeInt32, "", "")
+	ValueIntx(t, deviceResourceInt64, typeInt64, "-9223372036854775808", "9223372036854775807")
+	ValueIntx(t, deviceResourceInt64, typeInt64, "", "")
 }
 
 func TestValueUintx(t *testing.T) {
-	ValueUintx(t, deviceResourceUint8, "0", "255")
-	ValueUintx(t, deviceResourceUint8, "", "")
-	ValueUintx(t, deviceResourceUint16, "0", "65535")
-	ValueUintx(t, deviceResourceUint16, "", "")
-	ValueUintx(t, deviceResourceUint32, "0", "4294967295")
-	ValueUintx(t, deviceResourceUint32, "", "")
-	ValueUintx(t, deviceResourceUint64, "0", "18446744073709551615")
-	ValueUintx(t, deviceResourceUint64, "", "")
+	ValueUintx(t, deviceResourceUint8, typeUint8, "0", "255")
+	ValueUintx(t, deviceResourceUint8, typeUint8, "", "")
+	ValueUintx(t, deviceResourceUint16, typeUint16, "0", "65535")
+	ValueUintx(t, deviceResourceUint16, typeUint16, "", "")
+	ValueUintx(t, deviceResourceUint32, typeUint32, "0", "4294967295")
+	ValueUintx(t, deviceResourceUint32, typeUint32, "", "")
+	ValueUintx(t, deviceResourceUint64, typeUint64, "0", "18446744073709551615")
+	ValueUintx(t, deviceResourceUint64, typeUint64, "", "")
 }
 
 func TestValueFloatx(t *testing.T) {
-	ValueFloatx(t, deviceResourceFloat32, "-3.40282346638528859811704183484516925440e+38", "3.40282346638528859811704183484516925440e+38")
-	ValueFloatx(t, deviceResourceFloat32, "", "")
-	ValueFloatx(t, deviceResourceFloat64, "-1.797693134862315708145274237317043567981e+308", "1.797693134862315708145274237317043567981e+308")
-	ValueFloatx(t, deviceResourceFloat64, "", "")
+	ValueFloatx(t, deviceResourceFloat32, typeFloat32, "-3.40282346638528859811704183484516925440e+38", "3.40282346638528859811704183484516925440e+38")
+	ValueFloatx(t, deviceResourceFloat32, typeFloat32, "", "")
+	ValueFloatx(t, deviceResourceFloat64, typeFloat64, "-1.797693134862315708145274237317043567981e+308", "1.797693134862315708145274237317043567981e+308")
+	ValueFloatx(t, deviceResourceFloat64, typeFloat64, "", "")
 }
 
-func ValueIntx(t *testing.T, dr, minStr, maxStr string) {
+func ValueIntx(t *testing.T, dr, typeName, minStr, maxStr string) {
 	db := getDb()
 	if err := db.openDb(); err != nil {
 		t.Fatal(err)
@@ -183,7 +194,7 @@ func ValueIntx(t *testing.T, dr, minStr, maxStr string) {
 
 	var i1 int64
 	for x := 1; x <= rounds; x++ {
-		vn, err := vd.read(deviceName, dr, minStr, maxStr, db)
+		vn, err := vd.read(deviceName, dr, typeName, minStr, maxStr, db)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -202,7 +213,7 @@ func ValueIntx(t *testing.T, dr, minStr, maxStr string) {
 
 	//generate read 100 times
 	for x := 1; x <= rounds; x++ {
-		v, err := vd.read(deviceName, dr, minStr, maxStr, db)
+		v, err := vd.read(deviceName, dr, typeName, minStr, maxStr, db)
 
 		if err != nil {
 			t.Fatal(err)
@@ -223,10 +234,10 @@ func ValueIntx(t *testing.T, dr, minStr, maxStr string) {
 		t.Fatal(err)
 	}
 
-	v1, _ := vd.read(deviceName, dr, minStr, maxStr, db)
+	v1, _ := vd.read(deviceName, dr, typeName, minStr, maxStr, db)
 	i1 = getIntValue(v1)
 	for x := 1; x <= rounds; x++ {
-		v2, _ := vd.read(deviceName, dr, minStr, maxStr, db)
+		v2, _ := vd.read(deviceName, dr, typeName, minStr, maxStr, db)
 		i2 := getIntValue(v2)
 		if i1 != i2 {
 			t.Fatalf("EnableRandomization is false, but got different read")
@@ -234,7 +245,7 @@ func ValueIntx(t *testing.T, dr, minStr, maxStr string) {
 	}
 }
 
-func ValueUintx(t *testing.T, dr, minStr, maxStr string) {
+func ValueUintx(t *testing.T, dr, typeName, minStr, maxStr string) {
 	db := getDb()
 	if err := db.openDb(); err != nil {
 		t.Fatal(err)
@@ -259,7 +270,7 @@ func ValueUintx(t *testing.T, dr, minStr, maxStr string) {
 
 	var i1 uint64
 	for x := 1; x <= rounds; x++ {
-		vn, _ := vd.read(deviceName, dr, minStr, maxStr, db)
+		vn, _ := vd.read(deviceName, dr, typeName, minStr, maxStr, db)
 		in := getUintValue(vn)
 
 		if x == 1 {
@@ -275,7 +286,7 @@ func ValueUintx(t *testing.T, dr, minStr, maxStr string) {
 
 	//generate read 100 times
 	for x := 1; x <= rounds; x++ {
-		v, err := vd.read(deviceName, dr, minStr, maxStr, db)
+		v, err := vd.read(deviceName, dr, typeName, minStr, maxStr, db)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -295,10 +306,10 @@ func ValueUintx(t *testing.T, dr, minStr, maxStr string) {
 		t.Fatal(err)
 	}
 
-	v1, _ := vd.read(deviceName, dr, minStr, maxStr, db)
+	v1, _ := vd.read(deviceName, dr, typeName, minStr, maxStr, db)
 	i1 = getUintValue(v1)
 	for x := 1; x <= rounds; x++ {
-		v2, _ := vd.read(deviceName, dr, minStr, maxStr, db)
+		v2, _ := vd.read(deviceName, dr, typeName, minStr, maxStr, db)
 		i2 := getUintValue(v2)
 		if i1 != i2 {
 			t.Fatalf("EnableRandomization is false, but got different read")
@@ -306,7 +317,7 @@ func ValueUintx(t *testing.T, dr, minStr, maxStr string) {
 	}
 }
 
-func ValueFloatx(t *testing.T, dr, minStr, maxStr string) {
+func ValueFloatx(t *testing.T, dr, typeName, minStr, maxStr string) {
 	db := getDb()
 	if err := db.openDb(); err != nil {
 		t.Fatal(err)
@@ -331,7 +342,7 @@ func ValueFloatx(t *testing.T, dr, minStr, maxStr string) {
 
 	var f1 float64
 	for x := 1; x <= rounds; x++ {
-		vn, _ := vd.read(deviceName, dr, minStr, maxStr, db)
+		vn, _ := vd.read(deviceName, dr, typeName, minStr, maxStr, db)
 		fn := getFloatValue(vn)
 		if x == 1 {
 			f1 = fn
@@ -346,7 +357,7 @@ func ValueFloatx(t *testing.T, dr, minStr, maxStr string) {
 
 	//generate read 100 times
 	for x := 1; x <= rounds; x++ {
-		v, err := vd.read(deviceName, dr, minStr, maxStr, db)
+		v, err := vd.read(deviceName, dr, typeName, minStr, maxStr, db)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -366,10 +377,10 @@ func ValueFloatx(t *testing.T, dr, minStr, maxStr string) {
 		t.Fatal(err)
 	}
 
-	v1, _ := vd.read(deviceName, dr, minStr, maxStr, db)
+	v1, _ := vd.read(deviceName, dr, typeName, minStr, maxStr, db)
 	f1 = getFloatValue(v1)
 	for x := 1; x <= rounds; x++ {
-		v2, _ := vd.read(deviceName, dr, minStr, maxStr, db)
+		v2, _ := vd.read(deviceName, dr, typeName, minStr, maxStr, db)
 		f2 := getFloatValue(v2)
 		if f1 != f2 {
 			t.Fatalf("EnableRandomization is false, but got different read")

--- a/driver/virtualdriver.go
+++ b/driver/virtualdriver.go
@@ -134,7 +134,7 @@ func (d *VirtualDriver) HandleReadCommands(deviceName string, protocols map[stri
 
 	for i, req := range reqs {
 		if dr, ok := sdkService.DeviceResource(deviceName, req.DeviceResourceName, ""); ok {
-			if v, err := vd.read(deviceName, req.DeviceResourceName, dr.Properties.Value.Minimum, dr.Properties.Value.Maximum, d.db); err != nil {
+			if v, err := vd.read(deviceName, req.DeviceResourceName, dr.Properties.Value.Type, dr.Properties.Value.Minimum, dr.Properties.Value.Maximum, d.db); err != nil {
 				return nil, err
 			} else {
 				res[i] = v


### PR DESCRIPTION
Support value type:
Bool,
Int8, Int16, Int32, Int64,
Uint8, Uint16, Uint32, Uint64
Float32, Float64

Restricted: To control the randomization of device resource values, we
have to add additional device resources with the prefix
"**EnableRandomization_**" for each device resource.
(Need to do the same for device commands and core commands)
Please find the default device profile for example

fix: #17 

Signed-off-by: Felix Ting <felix@iotechsys.com>