### PR TITLE
Update docker entrypoint params to run with consul

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ EXPOSE $APP_PORT
 
 COPY --from=builder /github.com/edgexfoundry/device-virtual/cmd /
 
-ENTRYPOINT ["/device-virtual","--profile=docker","--confdir=/res"]
+ENTRYPOINT ["/device-virtual","--profile=docker","--confdir=/res","--registry=consul://edgex-core-consul:8500"]


### PR DESCRIPTION
Add flag "--registry=consul://edgex-core-consul:8500" to the Dockerfile
ENTRYPOINT

fix: #57 

Signed-off-by: Felix Ting <felix@iotechsys.com>