### PR TITLE
Update SDK version to v1.1.1 and add missing attributions

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -134,3 +134,9 @@ https://github.com/golang/net/blob/master/LICENSE
 
 golang.org/x/sys (Unspecified) https://github.com/golang/sys
 https://github.com/golang/sys/blob/master/LICENSE
+
+jessevdk/go-flags (BSD-3) https://github.com/jessevdk/go-flags
+https://github.com/jessevdk/go-flags/blob/master/LICENSE
+
+OneOfOne/xxhash (Apache 2.0) https://github.com/OneOfOne/xxhash
+https://github.com/OneOfOne/xxhash/blob/master/LICENSE

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/edgexfoundry/device-virtual-go
 
 require (
-	github.com/edgexfoundry/device-sdk-go v1.1.0
+	github.com/edgexfoundry/device-sdk-go v1.1.1
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.31
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/golang/snappy v0.0.1 // indirect


### PR DESCRIPTION
update device-sdk-go to v1.1.1 and add missing attributions

Fix #70 