### PR TITLE
Remove DisconnectDevice function

### DIFF
--- a/driver/virtualdriver.go
+++ b/driver/virtualdriver.go
@@ -47,11 +47,6 @@ func (d *VirtualDriver) retrieveVirtualDevice(deviceName string) (vdv *virtualDe
 	return vdv
 }
 
-func (d *VirtualDriver) DisconnectDevice(deviceName string, protocols map[string]models.ProtocolProperties) error {
-	d.lc.Info(fmt.Sprintf("VirtualDriver.DisconnectDevice: device-virtual driver is disconnecting to %s", deviceName))
-	return nil
-}
-
 func (d *VirtualDriver) Initialize(lc logger.LoggingClient, asyncCh chan<- *dsModels.AsyncValues) error {
 	d.lc = lc
 	d.asyncCh = asyncCh


### PR DESCRIPTION
DisconnectDevice func has been removed from protocoldriver interface of Device SDK

fix: #74 

Signed-off-by: Felix Ting <felix@iotechsys.com>