### PR TITLE
Reduce time consumption of unit test

### DIFF
--- a/internal/driver/virtualdevice_test.go
+++ b/internal/driver/virtualdevice_test.go
@@ -34,6 +34,7 @@ const (
 	deviceCommandNameFloat32 = "Float32"
 	deviceCommandNameFloat64 = "Float64"
 	enableRandomizationTrue  = "true"
+	rounds                   = 10
 )
 
 func init() {
@@ -111,7 +112,6 @@ func TestValue_Bool(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rounds := 20
 	//EnableRandomization = true
 	for x := 1; x <= rounds; x++ {
 		v2, _ := vd.read(deviceName, deviceResourceBool, typeBool, "", "", db)
@@ -187,8 +187,6 @@ func ValueIntx(t *testing.T, dr, typeName, minStr, maxStr string) {
 
 	vd := newVirtualDevice()
 
-	rounds := 100
-
 	min, _ := parseStrToInt(minStr, 64)
 	max, _ := parseStrToInt(maxStr, 64)
 
@@ -211,7 +209,6 @@ func ValueIntx(t *testing.T, dr, typeName, minStr, maxStr string) {
 		}
 	}
 
-	//generate read 100 times
 	for x := 1; x <= rounds; x++ {
 		v, err := vd.read(deviceName, dr, typeName, minStr, maxStr, db)
 
@@ -263,8 +260,6 @@ func ValueUintx(t *testing.T, dr, typeName, minStr, maxStr string) {
 
 	vd := newVirtualDevice()
 
-	rounds := 100
-
 	min, _ := parseStrToUint(minStr, 64)
 	max, _ := parseStrToUint(maxStr, 64)
 
@@ -284,7 +279,6 @@ func ValueUintx(t *testing.T, dr, typeName, minStr, maxStr string) {
 		}
 	}
 
-	//generate read 100 times
 	for x := 1; x <= rounds; x++ {
 		v, err := vd.read(deviceName, dr, typeName, minStr, maxStr, db)
 		if err != nil {
@@ -335,8 +329,6 @@ func ValueFloatx(t *testing.T, dr, typeName, minStr, maxStr string) {
 
 	vd := newVirtualDevice()
 
-	rounds := 100
-
 	min, _ := parseStrToFloat(minStr, 64)
 	max, _ := parseStrToFloat(maxStr, 64)
 
@@ -355,7 +347,6 @@ func ValueFloatx(t *testing.T, dr, typeName, minStr, maxStr string) {
 		}
 	}
 
-	//generate read 100 times
 	for x := 1; x <= rounds; x++ {
 		v, err := vd.read(deviceName, dr, typeName, minStr, maxStr, db)
 		if err != nil {


### PR DESCRIPTION
Reduce the rounds of generating and checking random value in unit test from 100 to 10 to improve the time consumption.

Resolve: #91 

Signed-off-by: Felix Ting <felix@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: Refine unit test

Issue Number: #91 

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No


## Are there any specific instructions or things that should be known prior to reviewing?
N/A
