### PR TITLE
fix: ReadWrite field of each device resource should be RW

### DIFF
--- a/cmd/res/device.virtual.bool.yaml
+++ b/cmd/res/device.virtual.bool.yaml
@@ -19,7 +19,7 @@ deviceResources:
   description: "Generate random boolean value"
   properties:
     value:
-      { type: "Bool", readWrite: "R", defaultValue: "true" }
+      { type: "Bool", readWrite: "RW", defaultValue: "true" }
     units:
       { type: "String", readWrite: "R", defaultValue: "random bool value" }
 

--- a/cmd/res/device.virtual.float.yaml
+++ b/cmd/res/device.virtual.float.yaml
@@ -27,7 +27,7 @@ deviceResources:
   description: "Generate random float32 value"
   properties:
     value:
-      { type: "Float32", readWrite: "R", defaultValue: "0", floatEncoding: "Base64" }
+      { type: "Float32", readWrite: "RW", defaultValue: "0", floatEncoding: "Base64" }
     units:
       { type: "String", readWrite: "R", defaultValue: "random float32 value" }
 -
@@ -35,7 +35,7 @@ deviceResources:
   description: "Generate random float64 value"
   properties:
     value:
-      { type: "Float64", readWrite: "R", defaultValue: "0", floatEncoding: "eNotation" }
+      { type: "Float64", readWrite: "RW", defaultValue: "0", floatEncoding: "eNotation" }
     units:
       { type: "String", readWrite: "R", defaultValue: "random float64 value" }
 

--- a/cmd/res/device.virtual.int.yaml
+++ b/cmd/res/device.virtual.int.yaml
@@ -43,7 +43,7 @@ deviceResources:
   description: "Generate random int8 value"
   properties:
     value:
-      { type: "Int8", readWrite: "R", defaultValue: "0" }
+      { type: "Int8", readWrite: "RW", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "random int8 value" }
 -
@@ -51,7 +51,7 @@ deviceResources:
   description: "Generate random int16 value"
   properties:
     value:
-      { type: "Int16", readWrite: "R", defaultValue: "0" }
+      { type: "Int16", readWrite: "RW", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "random int16 value" }
 -
@@ -59,7 +59,7 @@ deviceResources:
   description: "Generate random int32 value"
   properties:
     value:
-      { type: "Int32", readWrite: "R", defaultValue: "0" }
+      { type: "Int32", readWrite: "RW", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "random int32 value" }
 -
@@ -67,7 +67,7 @@ deviceResources:
   description: "Generate random int64 value"
   properties:
     value:
-      { type: "Int64", readWrite: "R", defaultValue: "0" }
+      { type: "Int64", readWrite: "RW", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "random int64 value" }
 

--- a/cmd/res/device.virtual.uint.yaml
+++ b/cmd/res/device.virtual.uint.yaml
@@ -43,7 +43,7 @@ deviceResources:
   description: "Generate random uint8 value"
   properties:
     value:
-      { type: "Uint8", readWrite: "R", defaultValue: "0" }
+      { type: "Uint8", readWrite: "RW", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "random uint8 value" }
 -
@@ -51,7 +51,7 @@ deviceResources:
   description: "Generate random uint16 value"
   properties:
     value:
-      { type: "Uint16", readWrite: "R", defaultValue: "0" }
+      { type: "Uint16", readWrite: "RW", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "random uint16 value" }
 -
@@ -59,7 +59,7 @@ deviceResources:
   description: "Generate random uint32 value"
   properties:
     value:
-      { type: "Uint32", readWrite: "R", defaultValue: "0" }
+      { type: "Uint32", readWrite: "RW", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "random uint32 value" }
 -
@@ -67,7 +67,7 @@ deviceResources:
   description: "Generate random uint64 value"
   properties:
     value:
-      { type: "Uint64", readWrite: "R", defaultValue: "0" }
+      { type: "Uint64", readWrite: "RW", defaultValue: "0" }
     units:
       { type: "String", readWrite: "R", defaultValue: "random uint64 value" }
 


### PR DESCRIPTION
In the sample device profiles, ReadWrite field of PropertyValue of each device resource should be RW, because they all support the Put command, except for Binary.

fix: #123 

Signed-off-by: Felix Ting <felix@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
The value of the ReadWrite permission field of PropertyValue of each device resource is `R`.
Issue Number: #123 


## What is the new behavior?
All the device resources but Binary can be operated via get/put command, so the ReadWrite permission fields of these device resources are now set to `RW`.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information