### PR TITLE
build: update device-sdk-go to 1.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/edgexfoundry/device-virtual-go
 
 require (
-	github.com/edgexfoundry/device-sdk-go v1.2.4-dev.34
+	github.com/edgexfoundry/device-sdk-go v1.3.0
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.97
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/golang/snappy v0.0.1 // indirect


### PR DESCRIPTION
Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
This PR updates device-virtual-go to the latest device-sdk-go release 1.3.0.

## What is the new behavior?
NA

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
No

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information
I tested this by building device-virtual-go as part of the main edgexfoundry snap. I installed, enabled device-virtual (to start it), and verified that the version logged was correct (we set VERSION explicitly in the snap build), and that auto event readings were being generated and no other error messages were see in the log output.
