### PR TITLE
fix: pass correct argument in prepareVirtualResources

### DIFF
--- a/internal/driver/virtualdriver.go
+++ b/internal/driver/virtualdriver.go
@@ -181,7 +181,7 @@ func prepareVirtualResources(driver *VirtualDriver, deviceName string) error {
 	if err != nil {
 		return err
 	}
-	profile, err := service.GetProfileByName(deviceName)
+	profile, err := service.GetProfileByName(device.ProfileName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-virtual-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
`prepareVirtualResources` would fail because not able to find profile in cache.
This bug wasn't found out earlier because device-virtual using the same name for example devices and profiles:
https://github.com/edgexfoundry/device-virtual-go/blob/bfe8b6d03e48aca57198d29dac0aa5fe93ed02ec/cmd/res/configuration.toml#L47-L48

## Issue Number: fix #176 


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
