### PR TITLE
feat: Add Registry/Config Access token capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@
 vendor/
 go.sum
 internal/driver/db/
+cmd/device-virtual
 cmd/db/
 VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ LABEL license='SPDX-License-Identifier: Apache-2.0' \
   copyright='Copyright (c) 2019-2021: IOTech'
 
 RUN sed -e 's/dl-cdn[.]alpinelinux.org/nl.alpinelinux.org/g' -i~ /etc/apk/repositories
-RUN apk add --update --no-cache zeromq
+RUN apk add --update --no-cache zeromq dumb-init
 
 WORKDIR /
 COPY --from=builder /device-virtual-go/Attribution.txt /

--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -52,6 +52,21 @@ PublishTopicPrefix = 'edgex/events' # /<device-profile-name>/<device-name>/<sour
   ClientAuth = "none" # Valid values are: `none`, `usernamepassword` or `clientcert`
   Secretpath = "messagebus"  # Path in secret store used if ClientAuth not `none`
 
+# Only used when EDGEX_SECURITY_SECRET_STORE=true which is now required for secure Consul
+[SecretStore]
+Type = 'vault'
+Host = 'localhost'
+Port = 8200
+Path = '/v1/secret/edgex/device-virtual/'
+Protocol = 'http'
+RootCaCertPath = ''
+ServerName = ''
+TokenFile = '/tmp/edgex/secrets/device-virtual/secrets-token.json'
+AdditionalRetryAttempts = 10
+RetryWaitPeriod = "1s"
+  [SecretStore.Authentication]
+  AuthType = 'X-Vault-Token'
+
 [Device]
   DataTransform = true
   InitCmd = ''

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/edgexfoundry/device-virtual-go
 
 require (
 	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0-dev.38
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.62
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.64
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20190321074620-2f0d2b0e0001 // indirect
@@ -20,4 +20,7 @@ require (
 	modernc.org/zappy v1.0.0 // indirect
 )
 
+replace (
+	github.com/edgexfoundry/device-sdk-go/v2 => ../../device-sdk-go
+)
 go 1.15

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/edgexfoundry/device-virtual-go
 
 require (
-	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0-dev.38
+	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0-dev.40
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.64
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
@@ -20,7 +20,4 @@ require (
 	modernc.org/zappy v1.0.0 // indirect
 )
 
-replace (
-	github.com/edgexfoundry/device-sdk-go/v2 => ../../device-sdk-go
-)
 go 1.15


### PR DESCRIPTION
closes 

Signed-off-by: lenny <leonard.goodell@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-virtual-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
Registry/Config access tokens capability now  supported

## Issue Number: #181


## What is the new behavior?
Registry/Config access tokens capability not supported


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: When run with the secure Edgex Stack now need to have the SecretStore configured, a Vault token created and run with EDGEX_SECURITY_SECRET_STORE=true.

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
