### PR TITLE
ci: update local docker image names in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,6 @@ docker: $(DOCKERS)
 docker_device_virtual_go:
 	docker build \
 		--label "git_sha=$(GIT_SHA)" \
-		-t edgexfoundry/docker-device-virtual-go:$(GIT_SHA) \
-		-t edgexfoundry/docker-device-virtual-go:$(VERSION)-dev \
+		-t edgexfoundry/device-virtual:$(GIT_SHA) \
+		-t edgexfoundry/device-virtual:$(VERSION)-dev \
 		.


### PR DESCRIPTION
As part of the Ireland release it was decided to remove the docker- in the image prefix and -go in the image suffix.