### PR TITLE
refactor: Update for new service key names and overrides for hyphen to underscore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN apk add --update --no-cache ${ALPINE_PKG_BASE} ${ALPINE_PKG_EXTRA}
 
 COPY . .
 
-RUN go mod download
 RUN go mod tidy
+RUN go mod download
 
 # To run tests in the build container:
 #   docker build --build-arg 'MAKE=build test' .

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apk add --update --no-cache ${ALPINE_PKG_BASE} ${ALPINE_PKG_EXTRA}
 COPY . .
 
 RUN go mod download
+RUN go mod tidy
 
 # To run tests in the build container:
 #   docker build --build-arg 'MAKE=build test' .

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,13 @@ GIT_SHA=$(shell git rev-parse HEAD)
 GOFLAGS=-ldflags "-X github.com/edgexfoundry/device-virtual-go.Version=$(VERSION)"
 
 build: $(MICROSERVICES)
-	$(GOCGO) build ./...
 
 cmd/device-virtual:
 	go mod tidy
 	$(GOCGO) build $(GOFLAGS) -o $@ ./cmd
 
 test:
+	go mod tidy
 	$(GOCGO) test ./... -coverprofile=coverage.out
 	$(GOCGO) vet ./...
 	gofmt -l .

--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -29,12 +29,12 @@ Port = 8500
 Type = 'consul'
 
 [Clients]
-  [Clients.edgex-core-data]
+  [Clients.core-data]
   Protocol = 'http'
   Host = 'localhost'
   Port = 48080
 
-  [Clients.edgex-core-metadata]
+  [Clients.core-metadata]
   Protocol = 'http'
   Host = 'localhost'
   Port = 48081

--- a/cmd/res/devices/devices.toml
+++ b/cmd/res/devices/devices.toml
@@ -9,7 +9,7 @@
       Address = 'device-virtual-bool-01'
       Port = '300'
   [[DeviceList.AutoEvents]]
-    Frequency = '10s'
+    Interval = '10s'
     OnChange = false
     SourceName = 'Bool'
 [[DeviceList]]
@@ -22,19 +22,19 @@
       Address = 'device-virtual-int-01'
       Protocol = '300'
   [[DeviceList.AutoEvents]]
-    Frequency = '15s'
+    Interval = '15s'
     OnChange = false
     SourceName = 'Int8'
   [[DeviceList.AutoEvents]]
-    Frequency = '15s'
+    Interval = '15s'
     OnChange = false
     SourceName = 'Int16'
   [[DeviceList.AutoEvents]]
-    Frequency = '15s'
+    Interval = '15s'
     OnChange = false
     SourceName = 'Int32'
   [[DeviceList.AutoEvents]]
-    Frequency = '15s'
+    Interval = '15s'
     OnChange = false
     SourceName = 'Int64'
 [[DeviceList]]
@@ -47,19 +47,19 @@
       Address = 'device-virtual-uint-01'
       Protocol = '300'
   [[DeviceList.AutoEvents]]
-    Frequency = '20s'
+    Interval = '20s'
     OnChange = false
     SourceName = 'Uint8'
   [[DeviceList.AutoEvents]]
-    Frequency = '20s'
+    Interval = '20s'
     OnChange = false
     SourceName = 'Uint16'
   [[DeviceList.AutoEvents]]
-    Frequency = '20s'
+    Interval = '20s'
     OnChange = false
     SourceName = 'Uint32'
   [[DeviceList.AutoEvents]]
-    Frequency = '20s'
+    Interval = '20s'
     OnChange = false
     SourceName = 'Uint64'
 [[DeviceList]]
@@ -72,11 +72,11 @@
       Address = 'device-virtual-float-01'
       Protocol = '300'
   [[DeviceList.AutoEvents]]
-    Frequency = '30s'
+    Interval = '30s'
     OnChange = false
     SourceName = 'Float32'
   [[DeviceList.AutoEvents]]
-    Frequency = '30s'
+    Interval = '30s'
     OnChange = false
     SourceName = 'Float64'
 [[DeviceList]]
@@ -89,6 +89,6 @@
       Address = 'device-virtual-binary-01'
       Port = '300'
 #  [[DeviceList.AutoEvents]]
-#    Frequency = '30s'
+#    Interval = '30s'
 #    OnChange = false
 #    SourceName = 'Binary'

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/edgexfoundry/device-virtual-go
 
 require (
-	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0-dev.58
+	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0-dev.63
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.90
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
@@ -19,7 +19,5 @@ require (
 	modernc.org/strutil v1.0.0 // indirect
 	modernc.org/zappy v1.0.0 // indirect
 )
-
-replace github.com/edgexfoundry/device-sdk-go/v2 => ../../device-sdk-go
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/edgexfoundry/device-virtual-go
 
 require (
 	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0-dev.58
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.83
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.90
 	github.com/edsrzf/mmap-go v1.0.0 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20190321074620-2f0d2b0e0001 // indirect
@@ -19,5 +19,7 @@ require (
 	modernc.org/strutil v1.0.0 // indirect
 	modernc.org/zappy v1.0.0 // indirect
 )
+
+replace github.com/edgexfoundry/device-sdk-go/v2 => ../../device-sdk-go
 
 go 1.16


### PR DESCRIPTION
**Dependent on edgexfoundry/go-mod-core-contracts#613
Dependent on edgexfoundry/go-mod-bootstrap#216
Dependent on https://github.com/edgexfoundry/device-sdk-go/pull/926**

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-virtual-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
Service key constants have the edgex- prefix

## Issue Number: #207 & #189


## What is the new behavior?
Service key constants no longer have the edgex- prefix
Hyphen in Overrides are converted to underscore

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: Service key names used in configuration have changed.

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
