### PR TITLE
fix: update separator for GET array value handler function

### DIFF
--- a/internal/driver/resourceboolarray.go
+++ b/internal/driver/resourceboolarray.go
@@ -34,7 +34,7 @@ func (rb *resourceBoolArray) value(db *db, deviceName, deviceResourceName string
 			newArrayBoolValue = append(newArrayBoolValue, rand.Int()%2 == 0)
 		}
 	} else {
-		strArr := strings.Split(strings.Trim(currentValue, "[]"), ",")
+		strArr := strings.Split(strings.Trim(currentValue, "[]"), " ")
 		for _, s := range strArr {
 			b, err := strconv.ParseBool(strings.Trim(s, " "))
 			if err != nil {

--- a/internal/driver/resourcefloatarray.go
+++ b/internal/driver/resourcefloatarray.go
@@ -45,7 +45,7 @@ func (rf *resourceFloatArray) value(db *db, deviceName, deviceResourceName, mini
 				newValueFloat32Array = append(newValueFloat32Array, float32(randomFloat(min, max)))
 			}
 		} else {
-			strArr := strings.Split(strings.Trim(currentValue, "[]"), ",")
+			strArr := strings.Split(strings.Trim(currentValue, "[]"), " ")
 			for _, s := range strArr {
 				f, err := strconv.ParseFloat(strings.Trim(s, " "), 32)
 				if err != nil {
@@ -66,7 +66,7 @@ func (rf *resourceFloatArray) value(db *db, deviceName, deviceResourceName, mini
 				newValueFloat64Array = append(newValueFloat64Array, randomFloat(min, max))
 			}
 		} else {
-			strArr := strings.Split(strings.Trim(currentValue, "[]"), ",")
+			strArr := strings.Split(strings.Trim(currentValue, "[]"), " ")
 			for _, s := range strArr {
 				f, err := strconv.ParseFloat(strings.Trim(s, " "), 64)
 				if err != nil {

--- a/internal/driver/resourceintarray.go
+++ b/internal/driver/resourceintarray.go
@@ -46,7 +46,7 @@ func (ri *resourceIntArray) value(db *db, deviceName, deviceResourceName, minimu
 				newArrayIntValue = append(newArrayIntValue, randomInt(min, max))
 			}
 		} else {
-			strArr := strings.Split(strings.Trim(currentValue, "[]"), ",")
+			strArr := strings.Split(strings.Trim(currentValue, "[]"), " ")
 			for _, s := range strArr {
 				i, err := strconv.ParseInt(strings.Trim(s, " "), 10, 8)
 				if err != nil {
@@ -70,7 +70,7 @@ func (ri *resourceIntArray) value(db *db, deviceName, deviceResourceName, minimu
 				newArrayIntValue = append(newArrayIntValue, randomInt(min, max))
 			}
 		} else {
-			strArr := strings.Split(strings.Trim(currentValue, "[]"), ",")
+			strArr := strings.Split(strings.Trim(currentValue, "[]"), " ")
 			for _, s := range strArr {
 				i, err := strconv.ParseInt(strings.Trim(s, " "), 10, 16)
 				if err != nil {
@@ -96,7 +96,7 @@ func (ri *resourceIntArray) value(db *db, deviceName, deviceResourceName, minimu
 				}
 			}
 		} else {
-			strArr := strings.Split(strings.Trim(currentValue, "[]"), ",")
+			strArr := strings.Split(strings.Trim(currentValue, "[]"), " ")
 			for _, s := range strArr {
 				i, err := strconv.ParseInt(strings.Trim(s, " "), 10, 32)
 				if err != nil {
@@ -122,7 +122,7 @@ func (ri *resourceIntArray) value(db *db, deviceName, deviceResourceName, minimu
 				}
 			}
 		} else {
-			strArr := strings.Split(strings.Trim(currentValue, "[]"), ",")
+			strArr := strings.Split(strings.Trim(currentValue, "[]"), " ")
 			for _, s := range strArr {
 				i, err := strconv.ParseInt(strings.Trim(s, " "), 10, 64)
 				if err != nil {

--- a/internal/driver/resourceuintarray.go
+++ b/internal/driver/resourceuintarray.go
@@ -44,7 +44,7 @@ func (ru *resourceUintArray) value(db *db, deviceName, deviceResourceName, minim
 				newArrayValueUint = append(newArrayValueUint, randomUint(min, max))
 			}
 		} else {
-			strArr := strings.Split(strings.Trim(currentValue, "[]"), ",")
+			strArr := strings.Split(strings.Trim(currentValue, "[]"), " ")
 			for _, s := range strArr {
 				i, err := strconv.ParseUint(strings.Trim(s, " "), 10, 8)
 				if err != nil {
@@ -68,7 +68,7 @@ func (ru *resourceUintArray) value(db *db, deviceName, deviceResourceName, minim
 				newArrayValueUint = append(newArrayValueUint, randomUint(min, max))
 			}
 		} else {
-			strArr := strings.Split(strings.Trim(currentValue, "[]"), ",")
+			strArr := strings.Split(strings.Trim(currentValue, "[]"), " ")
 			for _, s := range strArr {
 				i, err := strconv.ParseUint(strings.Trim(s, " "), 10, 16)
 				if err != nil {
@@ -94,7 +94,7 @@ func (ru *resourceUintArray) value(db *db, deviceName, deviceResourceName, minim
 				newArrayValueUint = append(newArrayValueUint, newValueUint)
 			}
 		} else {
-			strArr := strings.Split(strings.Trim(currentValue, "[]"), ",")
+			strArr := strings.Split(strings.Trim(currentValue, "[]"), " ")
 			for _, s := range strArr {
 				i, err := strconv.ParseUint(strings.Trim(s, " "), 10, 32)
 				if err != nil {
@@ -120,7 +120,7 @@ func (ru *resourceUintArray) value(db *db, deviceName, deviceResourceName, minim
 				newArrayValueUint = append(newArrayValueUint, newValueUint)
 			}
 		} else {
-			strArr := strings.Split(strings.Trim(currentValue, "[]"), ",")
+			strArr := strings.Split(strings.Trim(currentValue, "[]"), " ")
 			for _, s := range strArr {
 				i, err := strconv.ParseUint(strings.Trim(s, " "), 10, 64)
 				if err != nil {


### PR DESCRIPTION
Signed-off-by: Chris Hung <chris@iotechsys.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-virtual-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
v2 API `CommandValue.ValueToString()` will return string by just calling `fmt.Sprintf("%v", cv.Value)`.
For array data type the string format would be `[1 2 3 4]`, which is different from v1: `[1, 2, 3, 4]`
So we need to update the split separator.


## Issue Number: fix #218 


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
