### PR TITLE
refactor: Change PublishTopicPrefix value to be 'edgex/events/device'

### DIFF
--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -41,7 +41,7 @@ Port = 6379
 Type = 'redis'
 AuthMode = 'usernamepassword'  # required for redis messagebus (secure or insecure).
 SecretName = "redisdb"
-PublishTopicPrefix = 'edgex/events' # /<device-profile-name>/<device-name>/<source-name> will be added to this Publish Topic prefix
+PublishTopicPrefix = 'edgex/events/device' # /<device-profile-name>/<device-name>/<source-name> will be added to this Publish Topic prefix
   [MessageQueue.Optional]
   # Default MQTT Specific options that need to be here to enable environment variable overrides of them
   # Client Identifiers


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-virtual-go/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
PublishTopicPrefix value is 'edgex/events/' which doesn't allow Core Data to uniquely subscribe just to Device Service Events

## Issue Number: #220


## What is the new behavior?
PublishTopicPrefix value is 'edgex/events/device' which is unique to Device Services


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
