### PR TITLE
build(snap): Upgrade snap base to core22

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Build and upload snap
         id: build
-        uses: canonical/edgex-snap-testing/build@v2
+        uses: MonicaisHer/edgex-snap-testing/build@EDGEX-400-upgrade-snap-bases-to-core-22
     outputs:
       snap: ${{steps.build.outputs.snap}}
 

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Build and upload snap
         id: build
-        uses: MonicaisHer/edgex-snap-testing/build@EDGEX-400-upgrade-snap-bases-to-core-22
+        uses: canonical/edgex-snap-testing/build@v2
     outputs:
       snap: ${{steps.build.outputs.snap}}
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: edgex-device-virtual
-base: core20
+base: core22
 license: Apache-2.0
 adopt-info: metadata
 
@@ -43,9 +43,9 @@ parts:
     plugin: make
     build-snaps: [go/1.18/stable]
     override-build: |
-      cd $SNAPCRAFT_PART_SRC
+      cd $CRAFT_PART_SRC
       make build
-      install -DT ./helper-go $SNAPCRAFT_PART_INSTALL/bin/helper-go
+      install -DT ./helper-go $CRAFT_PART_INSTALL/bin/helper-go
 
   device-virtual:
     after: [metadata]
@@ -55,23 +55,22 @@ parts:
     build-snaps: [go/1.18/stable]
     stage-packages: [libzmq5]
     override-build: |
-      cd $SNAPCRAFT_PART_SRC
+      cd $CRAFT_PART_SRC
 
       # the version is needed for the build
-      cat VERSION
+      cp $CRAFT_STAGE/version.txt VERSION
 
-      make tidy
       make build
 
-      install -DT "./cmd/device-virtual" "$SNAPCRAFT_PART_INSTALL/bin/device-virtual"
+      install -DT "./cmd/device-virtual" "$CRAFT_PART_INSTALL/bin/device-virtual"
 
-      RES=$SNAPCRAFT_PART_INSTALL/config/device-virtual/res/
+      RES=$CRAFT_PART_INSTALL/config/device-virtual/res/
       mkdir -p $RES
       cp    cmd/res/configuration.toml $RES
       cp -r cmd/res/devices $RES
       cp -r cmd/res/profiles $RES
       
-      DOC=$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-virtual
+      DOC=$CRAFT_PART_INSTALL/usr/share/doc/device-virtual
       mkdir -p $DOC
       cp Attribution.txt $DOC/Attribution.txt
       cp LICENSE $DOC/LICENSE
@@ -90,10 +89,10 @@ parts:
     override-build: |
       # install the icon at the default internal path
       install -DT edgex-snap-icon.png \
-        $SNAPCRAFT_PART_INSTALL/meta/gui/icon.png
+        $CRAFT_PART_INSTALL/meta/gui/icon.png
       
       # change to this project's repo to get the version
-      cd $SNAPCRAFT_PROJECT_DIR
+      cd $CRAFT_PROJECT_DIR
       if git describe ; then
         VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
       else
@@ -101,9 +100,10 @@ parts:
       fi
       
       # write version to file for the build
-      echo $VERSION > ./VERSION
+      echo $VERSION > $CRAFT_STAGE/version.txt
+
       # set the version of this snap
-      snapcraftctl set-version $VERSION
+      craftctl set version=$VERSION
     parse-info: [edgex-device-virtual.metainfo.xml]
 
     


### PR DESCRIPTION
remove unused `make tidy`

Signed-off-by: Mengyi Wang <mengyi.wang@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-virtual-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-virtual-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?) [device-virtual test suite](https://github.com/canonical/edgex-snap-testing/tree/main/test/suites) passed with `FULL_CONFIG_TEST` enabled.
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->