### PR TITLE
build: Add option to build Core/Support services with NATS Capability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ FROM ${BASE} AS builder
 
 ARG ALPINE_PKG_BASE="make git openssh-client gcc libc-dev zeromq-dev libsodium-dev"
 ARG ALPINE_PKG_EXTRA=""
+ARG ADD_BUILD_TAGS=""
 
 # set the working directory
 WORKDIR /device-virtual-go
@@ -36,7 +37,7 @@ COPY . .
 # To run tests in the build container:
 #   docker build --build-arg 'MAKE=build test' .
 # This is handy of you do your Docker business on a Mac
-ARG MAKE='make build'
+ARG MAKE="make -e ADD_BUILD_TAGS=$ADD_BUILD_TAGS build"
 RUN $MAKE
 
 FROM alpine:3.16

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,14 @@ endif
 
 build: $(MICROSERVICES)
 
+build-nats:
+	make -e ADD_BUILD_TAGS=include_nats_messaging build
+
 tidy:
 	go mod tidy
 
 cmd/device-virtual:
-	$(GO) build $(CGOFLAGS) -o $@ ./cmd
+	$(GO) build -tags "$(ADD_BUILD_TAGS)" $(CGOFLAGS) -o $@ ./cmd
 
 
 unittest:
@@ -63,10 +66,14 @@ docker: $(DOCKERS)
 
 docker_device_virtual_go:
 	docker build \
+		--build-arg ADD_BUILD_TAGS=$(ADD_BUILD_TAGS) \
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/device-virtual:$(GIT_SHA) \
 		-t edgexfoundry/device-virtual:$(VERSION)-dev \
 		.
+
+docker-nats:
+	make -e ADD_BUILD_TAGS=include_nats_messaging docker
 
 vendor:
 	CGO_ENABLED=0 GO111MODULE=on go mod vendor

--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ The virtual device service simulates different kinds of [devices](https://docs.e
 ## Usage
 Users can refer to [the document](https://docs.edgexfoundry.org/2.1/microservices/device/virtual/Ch-VirtualDevice/) to learn how to use this device service.
 
+## Build with NATS Messaging
+Currently, the NATS Messaging capability (NATS MessageBus) is opt-in at build time.
+This means that the published Docker image and Snaps do not include the NATS messaging capability.
+
+The following make commands will build the local binary or local Docker image with NATS messaging
+capability included.
+```makefile
+make build-nats
+make docker-nats
+```
+
+The locally built Docker image can then be used in place of the published Docker image in your compose file.
+See [Compose Builder](https://github.com/edgexfoundry/edgex-compose/tree/main/compose-builder#gen) `nat-bus` option to generate compose file for NATS and local dev images.
+
 ## Community
 - Chat: https://edgexfoundry.slack.com
 - Mailing lists: https://lists.edgexfoundry.org/mailman/listinfo

--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -56,15 +56,21 @@ SecretName = "redisdb"
 PublishTopicPrefix = "edgex/events/device" # /<device-profile-name>/<device-name>/<source-name> will be added to this Publish Topic prefix
   [MessageQueue.Optional]
   # Default MQTT Specific options that need to be here to enable environment variable overrides of them
-  # Client Identifiers
   ClientId = "device-virtual"
-  # Connection information
-  Qos = "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
-  KeepAlive = "10" # Seconds (must be 2 or greater)
+  Qos =  "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
+  KeepAlive =  "10" # Seconds (must be 2 or greater)
   Retained = "false"
   AutoReconnect = "true"
   ConnectTimeout = "5" # Seconds
-  SkipCertVerify = "false" # Only used if Cert/Key file or Cert/Key PEMblock are specified
+  SkipCertVerify = "false"
+  # Default NATS Specific options that need to be here to enable evnironment variable overrides of them
+  Format = "nats"
+  RetryOnFailedConnect = "true"
+  QueueGroup = ""
+  Durable = ""
+  AutoProvision = "true"
+  Deliver = "new"
+  DefaultPubRetryAttempts = "2"
 
 # Only used when EDGEX_SECURITY_SECRET_STORE=true which is now required for secure Consul
 [SecretStore]


### PR DESCRIPTION
Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-virtual-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-virtual-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A*
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) ** README updated**
  <link to docs PR>

## Testing Instructions
Run the following commands and verify each Go build step includes `-tags "include_nats_messaging ...`
```
make build-nats
make docker-nats
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->