### PR TITLE
feat: Add NATS Subject configuration

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -182,3 +182,12 @@ https://github.com/microsoft/go-winio/blob/master/LICENSE
 
 golang.org/x/sync (Unspecified) https://cs.opensource.google/go/x/sync
 https://cs.opensource.google/go/x/sync/+/master:LICENSE
+
+github.com/nats-io/nats.go (Apache-2.0) https://github.com/nats-io/nats.go
+https://github.com/nats-io/nats.go/blob/main/LICENSE
+
+github.com/nats-io/nkeys (Apache-2.0) https://github.com/nats-io/nkeys
+https://github.com/nats-io/nkeys/blob/master/LICENSE
+
+github.com/nats-io/nuid (Apache-2.0) https://github.com/nats-io/nuid
+https://github.com/nats-io/nuid/blob/master/LICENSE

--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -55,7 +55,7 @@ AuthMode = "usernamepassword"  # required for redis messagebus (secure or insecu
 SecretName = "redisdb"
 PublishTopicPrefix = "edgex/events/device" # /<device-profile-name>/<device-name>/<source-name> will be added to this Publish Topic prefix
   [MessageQueue.Optional]
-  # Default MQTT Specific options that need to be here to enable environment variable overrides of them
+  # Default MQTT & NATS Specific options that need to be here to enable environment variable overrides of them
   ClientId = "device-virtual"
   Qos =  "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
   KeepAlive =  "10" # Seconds (must be 2 or greater)
@@ -71,6 +71,7 @@ PublishTopicPrefix = "edgex/events/device" # /<device-profile-name>/<device-name
   AutoProvision = "true"
   Deliver = "new"
   DefaultPubRetryAttempts = "2"
+  Subject = "edgex/#" # Required for NATS Jetstram only for stream autoprovsioning
   [MessageQueue.Topics]
   CommandRequestTopic = "edgex/command/request/device-virtual/#"  # subscribing for inbound command requests
   CommandResponseTopicPrefix = "edgex/command/response"   # publishing outbound command responses; <device-service>/<device-name>/<command-name>/<method> will be added to this publish topic prefix


### PR DESCRIPTION
Also updated to latest SDK which brought in more NATS dependencies

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-virtual-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-virtual-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?) 
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>

## Testing Instructions
run `make build-nats`
verify see `-tags "include_nats_messaging"  in the Go build line
run `make docker-nats`
verify see `-tags "include_nats_messaging"  in the Go build line

## New Dependency Instructions (If applicable)
New dependencies are from our own go-mod-messaging module. Not new to EdgeX